### PR TITLE
Add configurable language virtualization

### DIFF
--- a/directembedding/src/main/scala/ch/epfl/directembedding/DETransformer.scala
+++ b/directembedding/src/main/scala/ch/epfl/directembedding/DETransformer.scala
@@ -1,0 +1,86 @@
+package ch.epfl.directembedding
+
+import ch.epfl.directembedding.transformers.{ LiftLiteralTransformation, EndpointTransformation, DSLVirtualization, ReifyAsEmbedding }
+import ch.epfl.yinyang.analysis.FreeIdentAnalysis
+import ch.epfl.yinyang.transformers.{ LanguageVirtualization, NullPreProcessing, NullPostProcessing, PreProcessing, PostProcessing }
+
+import scala.reflect.macros.{ TypecheckException, blackbox }
+
+object DETransformer {
+
+  def typechecks[C <: blackbox.Context](c: C)(path: c.Tree): Boolean = {
+    import c.universe._
+    try {
+      c.typecheck(path)
+    } catch {
+      case e: TypecheckException =>
+        return false
+    }
+    true
+  }
+
+  def apply[C <: blackbox.Context, T](c: C)(
+    _dslName: String,
+    _configType: c.universe.Type,
+    postProcessing: Option[PostProcessing[c.type]],
+    preProcessing: Option[PreProcessing[c.type]]): DETransformer[c.type, T] = {
+    import c.universe._
+
+    val configName = _configType.typeSymbol.fullName
+    val dslConfig: Tree = c.parse(configName)
+    assert(typechecks(c)(q"import $dslConfig.lift"), s"Method lift is not a member of type $configName")
+    assert(typechecks(c)(q"import $dslConfig.dsl"), s"Method dsl is not a member of $configName")
+
+    new DETransformer[c.type, T](c) {
+      val postProcessor = postProcessing.getOrElse(new NullPostProcessing[c.type](c))
+      val preProcessor = preProcessing.getOrElse(new NullPreProcessing[c.type](c))
+      val dslName: String = _dslName
+      val configPath: Tree = dslConfig
+      val logLevel: Int = 1
+    }
+  }
+}
+
+abstract class DETransformer[C <: blackbox.Context, T](val c: C)
+  extends DirectEmbeddingModule
+  with ReifyAsEmbedding
+  with LanguageVirtualization
+  with DSLVirtualization
+  with FreeIdentAnalysis
+  with LiftLiteralTransformation
+  with EndpointTransformation {
+  type Ctx = C
+  import c.universe._
+  override val debugLevel: Int = 0
+  val postProcessor: PostProcessing[c.type]
+  val preProcessor: PreProcessing[c.type]
+  import postProcessor._
+  import preProcessor._
+
+  def apply[T](block: c.Expr[T]): c.Expr[T] = {
+
+    val tree = block.tree
+
+    val captured = freeVariables(tree)
+    val toLifted = captured.map(_.symbol)
+
+    val transformed: Tree = {
+      (PreProcess andThen
+        (x => c.untypecheck(x)) andThen
+        (x => VirtualizationTransformer(x)._1) andThen
+        DSLVirtualizer andThen
+        ReifyAsTransformer andThen
+        LiftLiteralTransformer(toLifted) andThen
+        EndpointTransformer andThen
+        (x => c.untypecheck(x)) andThen
+        PostProcess)(tree)
+    }
+    log("**********************", 2)
+    log("* After transformation", 2)
+    log("**********************", 2)
+    logTree(transformed, 2)
+
+    c.Expr[T](transformed)
+  }
+
+}

--- a/directembedding/src/main/scala/ch/epfl/directembedding/DirectEmbedding.scala
+++ b/directembedding/src/main/scala/ch/epfl/directembedding/DirectEmbedding.scala
@@ -1,6 +1,8 @@
 package ch.epfl.directembedding
 
 import ch.epfl.directembedding.transformers.ReifyAsEmbedding
+import ch.epfl.yinyang.transformers.LanguageVirtualization
+import ch.epfl.yinyang.EmbeddedControls
 
 import scala.reflect.macros.blackbox.Context
 
@@ -36,18 +38,6 @@ protected[directembedding] object Macros {
       ..${paramsMap.values.map(_._2)}
       ${c.untypecheck(inlinedBody)}
     }"""
-  }
-
-  def lift[T](c: Context)(block: c.Expr[T]): c.Expr[T] = {
-    import c.universe._
-
-    val reified = new ReifyAsLifter[c.type](c).lift(block.tree)
-    c.Expr[T](q"_root_.ch.epfl.directembedding.test.compile($reified)")
-  }
-
-  private final class ReifyAsLifter[C <: Context](val c: C) extends ReifyAsEmbedding {
-    type Ctx = C
-    val debugLevel = 0
   }
 
   def extractMethodTree(c: Context)(x: c.Expr[Any]): c.Expr[MethodTree] = {

--- a/directembedding/src/main/scala/ch/epfl/directembedding/Utils.scala
+++ b/directembedding/src/main/scala/ch/epfl/directembedding/Utils.scala
@@ -1,5 +1,8 @@
 package ch.epfl.directembedding
 
+import ch.epfl.yinyang.TransformationUtils
+
+import scala.reflect.macros.TypecheckException
 import scala.reflect.macros.blackbox.Context
 
 // Inspired by https://github.com/scala-yinyang/scala-yinyang/blob/16732662470992e10a7ae479d8be5419f13d3654/components/core/src/Utils.scala
@@ -10,11 +13,73 @@ trait MacroModule {
 }
 
 trait DirectEmbeddingModule extends MacroModule {
-  import c.universe._
-  def lift(tree: Tree): Tree
+  import c.universe.Tree
+  val dslName: String
+  /**
+   * Full name of configuration module
+   */
+  val configPath: Tree
+  val logLevel: Int
 }
 
-trait DirectEmbeddingUtils {
-  def debugLevel: Int
-  def log(s: => String, level: Int = 0) = if (debugLevel < level) println(s)
+/**
+ * Skeleton for Dsl config type
+ */
+trait DslConfig {
+  /**
+   * The type which literals get lifted to
+   * @tparam T
+   */
+  type Literal[T]
+  /**
+   * The IR top level type
+   * @tparam T
+   */
+  type Rep[T]
+
+  /**
+   * Endpoint for DSL. Mandatory.
+   * @param ast Constructed ast after applying directembedding transformation
+   * @tparam T
+   * @return Result type of the block
+   */
+  def dsl[T](ast: Rep[T]): T
+
+  /**
+   * The method invoked for lifting literals. Mandatory.
+   * @param e
+   * @tparam T
+   * @return
+   */
+  def lift[T](e: T): Literal[T]
+}
+
+trait DirectEmbeddingUtils extends MacroModule with TransformationUtils {
+  import c.universe._
+
+  def debugLevel: Int = 0
+  val failCompilation: Boolean = false
+  val virtualizeFunctions: Boolean = false
+  val virtualizeVal: Boolean = false
+
+  def logTree(t: Tree, level: Int = 0) = {
+    log(s"$t", level)
+    log(showRaw(t, printTypes = true), level + 1)
+  }
+
+  def logIndented[T](e: T, indent: Int, level: Int = 0) = if (debugLevel > level) {
+    print(" " * indent)
+    super.log(s"$e", level)
+  }
+
+  def importType(tpe: c.universe.Type): Tree = {
+    q"import ${c.parse(tpe.typeSymbol.fullName)}._"
+  }
+
+  def LogHereAndContinue(where: String)(t: Tree): Tree = {
+    super.log(where)
+    logTree(t)
+    t
+  }
+
 }

--- a/directembedding/src/main/scala/ch/epfl/directembedding/transformers/DSLVirtualization.scala
+++ b/directembedding/src/main/scala/ch/epfl/directembedding/transformers/DSLVirtualization.scala
@@ -1,0 +1,23 @@
+package ch.epfl.directembedding.transformers
+
+import ch.epfl.directembedding.{ DirectEmbeddingUtils, DirectEmbeddingModule }
+import ch.epfl.yinyang.EmbeddedControls
+
+object RewireEmbeddedControls extends EmbeddedControls
+
+trait DSLVirtualization extends DirectEmbeddingModule with DirectEmbeddingUtils {
+  import c.universe._
+
+  def DSLVirtualizer = new (Tree => Tree) {
+    def apply(tree: Tree) = {
+      c.typecheck(q"""
+      import _root_.ch.epfl.directembedding.transformers.RewireEmbeddedControls._
+      {
+          import $configPath._
+          $tree
+      }
+       """)
+    }
+  }
+
+}

--- a/directembedding/src/main/scala/ch/epfl/directembedding/transformers/EndpointTransformation.scala
+++ b/directembedding/src/main/scala/ch/epfl/directembedding/transformers/EndpointTransformation.scala
@@ -1,0 +1,18 @@
+package ch.epfl.directembedding.transformers
+
+import ch.epfl.directembedding.{ DirectEmbeddingModule, DirectEmbeddingUtils }
+
+trait EndpointTransformation extends DirectEmbeddingModule with DirectEmbeddingUtils {
+  import c.universe._
+
+  def EndpointTransformer = new (Tree => Tree) {
+
+    //    ${c.parse(dslEndpointMethod)}($tree)
+    def apply(tree: Tree): Tree = {
+      q"""
+          $configPath.dsl($tree)
+       """
+    }
+  }
+
+}

--- a/directembedding/src/main/scala/ch/epfl/directembedding/transformers/LiftLiteralTransformation.scala
+++ b/directembedding/src/main/scala/ch/epfl/directembedding/transformers/LiftLiteralTransformation.scala
@@ -1,0 +1,39 @@
+package ch.epfl.directembedding.transformers
+
+import ch.epfl.directembedding.{ DirectEmbeddingModule, DirectEmbeddingUtils }
+
+import language.experimental.macros
+
+trait LiftLiteralTransformation extends DirectEmbeddingModule with DirectEmbeddingUtils {
+  import c.universe._
+  object LiftLiteralTransformer {
+    def apply(toLift: List[Symbol])(tree: Tree): Tree = {
+      val t = new LiftLiteralTransformer(toLift).transform(tree)
+      log("lifted: " + t, 2)
+      t
+    }
+  }
+
+  class LiftLiteralTransformer(toLift: List[Symbol])
+    extends Transformer {
+
+    def genApply(t: List[Tree]) =
+      q"$configPath.lift(..$t)"
+
+    override def transform(tree: Tree): Tree = {
+      tree match {
+        case t @ Literal(Constant(_)) =>
+          genApply(List(t))
+        case t @ Ident(_) if toLift.contains(t.symbol) =>
+          genApply(List(Ident(TermName(t.name.decodedName.toString))))
+        // the type associated with the identifier will remain if we don't that
+        case t @ Ident(n) =>
+          log("local variable: " + t, 3)
+          Ident(n)
+        case _ =>
+          super.transform(tree)
+      }
+    }
+  }
+
+}

--- a/dsls/src/main/scala/ch/epfl/directembedding/test/TestBase.scala
+++ b/dsls/src/main/scala/ch/epfl/directembedding/test/TestBase.scala
@@ -12,13 +12,16 @@ case class JustArgs(x: Exp[Int]) extends Exp[Int]
 case class ArgsAndTArgs[T, U](t: Exp[T], u: Exp[U]) extends Exp[(T, U)]
 case class Const[T](x: T) extends Exp[T]
 
-case class Size[T](self: Exp[TArgClassExampleCase[T]]) extends Exp[Int]
-case class Take[T](self: Exp[TArgClassExampleCase[T]], n: Exp[Int]) extends Exp[TArgClassExample[T]]
-case class X[T](self: Exp[TArgClassExample[T]]) extends Exp[Int]
-case class Y[T](self: Exp[TArgClassExample[T]]) extends Exp[Int]
-case class TArgsZ[T, U](self: Exp[TArgClassExample[T]]) extends Exp[U]
-case class AppCurry[T](self: Exp[TArgClassExample[T]], p1: Exp[T], p2: Exp[T], p3: Exp[T]*) extends Exp[T]
-case class AppManyArgs[T](self: Exp[TArgClassExample[T]], p1: Exp[T]*) extends Exp[T]
+case class Size[T](self: Exp[_]) extends Exp[Int]
+case class Take[T](self: Exp[_], n: Exp[Int]) extends Exp[TArgClassExample[T]]
+case class X[T](self: Exp[_]) extends Exp[Int]
+case class Y[T](self: Exp[_]) extends Exp[Int]
+case class TArgsZ[T, U](self: Exp[_]) extends Exp[U]
+case class AppCurry[T](self: Exp[_], p1: Exp[T], p2: Exp[T], p3: Exp[T]*) extends Exp[T]
+case class AppManyArgs[T](self: Exp[_], p1: Exp[T]*) extends Exp[T]
+
+case class IF[T](cond: Exp[Boolean], e1: Exp[T], e2: Exp[T]) extends Exp[T]
+case class NewVar[T](e: Exp[T]) extends Exp[T]
 
 case object ClassCons extends Exp[ClassExample]
 case class TArgClassExampleCase[T]() extends Exp[TArgClassExample[T]]
@@ -42,7 +45,6 @@ object ObjectExample {
   @reifyAs(ArgsAndTArgs)
   def argsAndTArgs[T, U](t: T, u: U): (T, U) = ???
 
-  // TODO nested objects
   object nested {
     @reifyAs(ValDef)
     val valDef: Int = ???
@@ -58,7 +60,6 @@ object ObjectExample {
 
     @reifyAs(ArgsAndTArgs)
     def argsAndTArgs[T, U](t: T, u: U): (T, U) = ???
-
   }
 }
 

--- a/dsls/src/main/scala/ch/epfl/directembedding/test/example/package.scala
+++ b/dsls/src/main/scala/ch/epfl/directembedding/test/example/package.scala
@@ -1,0 +1,57 @@
+package ch.epfl.directembedding.test
+
+import ch.epfl.directembedding.{ DslConfig, DETransformer }
+import ch.epfl.directembedding.transformers.{ DSLVirtualization, reifyAs }
+import ch.epfl.yinyang.EmbeddedControls
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+
+package object example {
+  def dsl[T](block: T): T = macro implementations.liftRep[T]
+
+  implicit def liftConstant[T](x: T): Exp[T] = Const(x)
+
+  def compile[T](ast: Exp[T])(implicit collector: Collector): T = {
+    collector.add[T](ast)
+    ???
+  }
+
+  object ExampleConfig extends ExampleConfig
+
+  /**
+   * Configuration module for example DSL
+   *
+   * Note, your custom DSL is free to extend [[DslConfig]]. We don't extend
+   * [[DslConfig]] for this example because then we couldn't accept an implicit
+   * parameter in the [[dsl()]] method. We use the implicit parameter for
+   * testing purposes.
+   */
+  trait ExampleConfig extends VirtualizationOverrides {
+    def dsl[T](e: Exp[T])(implicit collector: Collector): T = {
+      collector.add[T](e)
+      ???
+    }
+    def lift[T](e: T): Const[T] = Const(e)
+  }
+
+  trait VirtualizationOverrides {
+    @reifyAs(IF)
+    def __ifThenElse[T](cond: Boolean, e1: T, e2: T): T = ???
+
+    @reifyAs(NewVar)
+    def __newVar(v: String): String = ???
+
+  }
+
+  object implementations {
+    def liftRep[T](c: Context)(block: c.Expr[T]): c.Expr[T] = {
+      val config = "ch.epfl.directembedding.test.example"
+      DETransformer[c.type, T](c)(
+        "example.dsl",
+        c.weakTypeTag[ExampleConfig].tpe,
+        None,
+        None)(block)
+    }
+  }
+}

--- a/dsls/src/main/scala/ch/epfl/directembedding/test/package.scala
+++ b/dsls/src/main/scala/ch/epfl/directembedding/test/package.scala
@@ -1,10 +1,9 @@
 package ch.epfl.directembedding
+
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox.Context
 
 package object test {
-  // For our DSL
-  def lift[T](block: T): T = macro Macros.lift[T]
 
   trait Collector {
     def add[T](ast: Exp[T])
@@ -20,13 +19,6 @@ package object test {
 
     def get: Seq[Exp[_]] = c
   }
-
-  def compile[T](ast: Exp[T])(implicit collector: Collector): T = {
-    collector.add[T](ast)
-    ???
-  }
-
-  implicit def liftConstant[T](x: T): Exp[T] = Const(x)
 
   // For testing purposes
   def persisted(x: Any): String = macro Persisted.persisted

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -37,7 +37,9 @@ object DirectEmbeddingBuild extends Build {
       scalaOrg % "scala-reflect" % ver,
       scalaOrg % "scala-compiler" % ver,
       "org.scalatest" % "scalatest_2.11" % "2.1.5" % "test",
-      "junit" % "junit" % "4.11" % "test" // we need JUnit explicitly
+      "junit" % "junit" % "4.11" % "test", // we need JUnit explicitly
+      "ch.epfl.lamp" % "scala-yinyang_2.11" % "0.1.0",
+      "ch.epfl.lamp" % "yinyang-paradise_2.11" % "0.1.0"
   )))
 
   // modules

--- a/tests/src/test/scala/ch/epfl/directembedding/test/BasicSpec.scala
+++ b/tests/src/test/scala/ch/epfl/directembedding/test/BasicSpec.scala
@@ -2,6 +2,7 @@ package ch.epfl.directembedding.test
 
 import org.scalatest.{ FlatSpec, ShouldMatchers }
 import Typecheck._
+import ch.epfl.directembedding.test.example._
 
 class BasicSpec extends FlatSpec with ShouldMatchers {
 
@@ -13,169 +14,208 @@ class BasicSpec extends FlatSpec with ShouldMatchers {
     collec.get
   }
 
-  "lift" should "work object fields" in {
+  "dsl" should "work object fields" in {
     testReify(implicit collec =>
-      lift {
+      dsl {
         ObjectExample.valDef
       }) should be(List(ValDef))
   }
 
-  "lift" should "work with object methods without arguments and type arguments" in {
+  "dsl" should "work with object methods without arguments and type arguments" in {
     testReify(implicit collec =>
-      lift {
+      dsl {
         ObjectExample.noArgs
       }) should be(List(NoArgs))
   }
 
-  "lift" should "work with object methods with just type arguments" in {
+  "dsl" should "work with object methods with just type arguments" in {
     testReify(implicit collec =>
-      lift {
+      dsl {
         ObjectExample.justTargs[TArgClassExample[Int], TArgClassExample[Int]]
       }) should be(List(JustTargs[TArgClassExample[Int], TArgClassExample[Int]]))
   }
 
-  "lift" should "work with object methods with just arguments" in {
+  "dsl" should "work with object methods with just arguments" in {
     testReify(implicit collec =>
-      lift {
+      dsl {
         ObjectExample.justArgs(1)
       }) should be(List(JustArgs(Const(1))))
   }
 
-  "lift" should "work with object methods with arguments and type arguments" in {
+  "dsl" should "work with object methods with arguments and type arguments" in {
     testReify(implicit collec =>
-      lift {
+      dsl {
         ObjectExample.argsAndTArgs[Int, Boolean](1, true)
       }) should be(List(ArgsAndTArgs[Int, Boolean](Const(1), Const(true))))
   }
 
-  "lift" should "work nested object fields" in {
+  "dsl" should "work nested object fields" in {
     testReify(implicit collec =>
-      lift {
+      dsl {
         ObjectExample.nested.valDef
       }) should be(List(ValDef))
   }
 
-  "lift" should "work with nested object methods without arguments and type arguments" in {
+  "dsl" should "work with nested object methods without arguments and type arguments" in {
     testReify(implicit collec =>
-      lift {
+      dsl {
         ObjectExample.nested.noArgs
       }) should be(List(NoArgs))
   }
 
-  "lift" should "work with nested object methods with just type arguments" in {
+  "dsl" should "work with nested object methods with just type arguments" in {
     testReify(implicit collec =>
-      lift {
+      dsl {
         ObjectExample.nested.justTargs[TArgClassExample[Int], TArgClassExample[Int]]
       }) should be(List(JustTargs[TArgClassExample[Int], TArgClassExample[Int]]))
   }
 
-  "lift" should "work with nested object methods with just arguments" in {
+  "dsl" should "work with nested object methods with just arguments" in {
     testReify(implicit collec =>
-      lift {
+      dsl {
         ObjectExample.nested.justArgs(1)
       }) should be(List(JustArgs(Const(1))))
   }
 
-  "lift" should "work with nested object methods with arguments and type arguments" in {
+  "dsl" should "work with nested object methods with arguments and type arguments" in {
     testReify(implicit collec =>
-      lift {
+      dsl {
         ObjectExample.nested.argsAndTArgs[Int, Boolean](1, true)
       }) should be(List(ArgsAndTArgs[Int, Boolean](Const(1), Const(true))))
   }
 
-  "lift" should "work with TArgClassExample methods with size" in {
+  "dsl" should "work with TArgClassExample methods with size" in {
     testReify(implicit collec =>
-      lift {
+      dsl {
         new TArgClassExample[Int].size
       }) should be(List(Size[Int](TArgClassExampleCase[Int]())))
   }
 
-  "lift" should "work with TArgClassExample methods with take" in {
+  "dsl" should "work with TArgClassExample methods with take" in {
     testReify(implicit collec =>
-      lift {
+      dsl {
         new TArgClassExample[Int].take(3)
       }) should be(List(Take[Int](TArgClassExampleCase[Int](), 3)))
   }
 
+  "lift" should "work with TArgClassExample methods with nested take" in {
+    testReify(implicit collec =>
+      dsl {
+        new TArgClassExample[Int].take(1).take(2)
+      }) should be(List(Take[Int](Take[Int](TArgClassExampleCase[Int](), Const(1)), Const(2))))
+  }
+
   "lift" should "work with TArgClassExample methods with val x" in {
     testReify(implicit collec =>
-      lift {
+      dsl {
         new TArgClassExample[Int].x
       }) should be(List(X[Int](TArgClassExampleCase[Int]())))
   }
 
-  "lift" should "work with TArgClassExample methods with val y" in {
+  "dsl" should "work with TArgClassExample methods with val y" in {
     testReify(implicit collec =>
-      lift {
+      dsl {
         new TArgClassExample[Int].y
       }) should be(List(Y[Int](TArgClassExampleCase[Int]())))
   }
 
-  "lift" should "work with TArgClassExample methods with method type" in {
+  "dsl" should "work with TArgClassExample methods with method type" in {
     testReify(implicit collec =>
-      lift {
+      dsl {
         new TArgClassExample[Boolean].z[Int]
       }) should be(List(TArgsZ[Boolean, Int](TArgClassExampleCase[Boolean]())))
   }
 
-  "lift" should "work with TArgClassExample methods with app 0 args" in {
+  "dsl" should "work with TArgClassExample methods with app 0 args" in {
     testReify(implicit collec =>
-      lift {
+      dsl {
         new TArgClassExample[Int].app1[Int]()
       }) should be(List(AppManyArgs[Int](TArgClassExampleCase[Int])))
   }
 
-  "lift" should "work with TArgClassExample methods with app 1 args" in {
+  "dsl" should "work with TArgClassExample methods with app 1 args" in {
     testReify(implicit collec =>
-      lift {
+      dsl {
         new TArgClassExample[Int].app1[Int](1)
       }) should be(List(AppManyArgs[Int](TArgClassExampleCase[Int], 1))) // Const(1) ?
   }
 
-  "lift" should "work with TArgClassExample methods with app many args" in {
+  "dsl" should "work with TArgClassExample methods with app many args" in {
     testReify(implicit collec =>
-      lift {
+      dsl {
         new TArgClassExample[Int].app1[Int](1, 2)
       }) should be(List(AppManyArgs[Int](TArgClassExampleCase[Int], Const(1), Const(2))))
   }
 
-  "lift" should "work with construction of ClassExample" in {
+  "dsl" should "work with construction of ClassExample" in {
     testReify(implicit collec =>
-      lift {
+      dsl {
         new ClassExample
       }) should be(List(ClassCons))
   }
 
-  "lift" should "work with curry functions" in {
+  "dsl" should "work with curry functions" in {
     testReify(implicit collec =>
-      lift {
+      dsl {
         new TArgClassExample[Int].appCurry1[Int](1)(2)
       }) should be(List(AppCurry[Int](TArgClassExampleCase[Int], 1, 2)))
   }
 
-  "lift" should "work with curry functions, twice" in {
+  "dsl" should "work with curry functions, twice" in {
     testReify(implicit collec =>
-      lift {
+      dsl {
         new TArgClassExample[Int].appCurry2[Int](1)(2)(3)
       }) should be(List(AppCurry[Int](TArgClassExampleCase[Int], 1, 2, 3)))
   }
 
-  "lift" should "take the last expression in blocks" in {
+  "dsl" should "evaluate to the last expression in blocks" in {
     testReify(implicit collec =>
-      lift {
-        println("debug")
+      dsl {
+        ObjectExample.noArgs
         ObjectExample.valDef
       }) should be(List(ValDef))
   }
 
-  "lift" should "give a useful error when a reifyAs annotation is missing" in {
+  "dsl" should "work with a virtualized boolean __ifThenElse" in {
+    testReify(implicit collec =>
+      dsl {
+        if (true) ObjectExample.valDef else ObjectExample.noArgs
+      }) should be(List(IF(Const(true), ValDef, NoArgs)))
+  }
+
+  "dsl" should "work with a virtualized boolean __ifThenElse in block" in {
+    testReify(implicit collec =>
+      dsl {
+        val result = if (true) ObjectExample.valDef else ObjectExample.noArgs
+        result
+      }) should be(List(IF(true, ValDef, NoArgs)))
+  }
+
+  "dsl" should "work with a virtualized __newVar in block" in {
+    testReify(implicit collec =>
+      dsl {
+        var result = "result"
+        result
+      }) should be(List(NewVar(Const("result"))))
+  }
+
+  "dsl" should "lift free variables in block" in {
+    val b = true
+    testReify(implicit collec =>
+      dsl {
+        b
+      }) should be(List(Const(b)))
+  }
+
+  "dsl" should "give a useful error when a reifyAs annotation is missing" in {
     typedWithMsg(
       """
         testReify(implicit collec =>
-          lift {
+          dsl {
             ObjectExample.missingAnnotation
         }) should be(List(???))
-      """, "Missing reifyAs annotation for method missingAnnotation")
+      """, "method missingAnnotation is not supported in example.dsl")
+
   }
 
 }


### PR DESCRIPTION
I moved the `lift` dsl into a separate `example` package, which uses the new configuration methods from `DETransformer`, inspired by the `YYTransformer` in yinyang.