### PR TITLE
Unify Apply(lhs, rhs) into one case in ReifyAsEmbedding

### DIFF
--- a/directembedding/src/main/scala/ch/epfl/directembedding/transformers/ReifyAsEmbedding.scala
+++ b/directembedding/src/main/scala/ch/epfl/directembedding/transformers/ReifyAsEmbedding.scala
@@ -18,24 +18,26 @@ trait ReifyAsEmbedding extends DirectEmbeddingModule with DirectEmbeddingUtils {
   final class ReifyAsTransformer(pos: Position) extends Transformer {
     def apply(tree: Tree): Tree = transform(tree)
 
-    def getReifyAnnotation(methodSym: Symbol, typ: Type): Option[Annotation] = methodSym.annotations.find(_.tree.tpe <:< typ)
+    private def getReifyAnnotation(methodSym: Symbol): Option[Annotation] =
+      methodSym.annotations.find(_.tree.tpe <:< c.typeOf[reifyAs])
 
-    def reify(methodSym: Symbol, targs: List[Tree], args: List[Tree]): Tree = {
-      val reifyAsAnnot = getReifyAnnotation(methodSym, c.typeOf[reifyAs]).getOrElse {
+    private def reify(methodSym: Symbol, targs: List[Tree], args: List[Tree]): Tree = {
+      val annotation = getReifyAnnotation(methodSym).getOrElse {
         c.abort(pos, s"$methodSym is not supported in $dslName")
       }
+      reify(annotation.tree.children.tail.head, targs, args)
+    }
 
-      val body :: _ = reifyAsAnnot.tree.children.tail
-
+    private def reify(body: Tree, targs: List[Tree], args: List[Tree]): Tree = {
       (targs, args) match {
         case (Nil, Nil)    => body
-        case (targs, Nil)  => q"${body}.apply[..$targs]"
-        case (Nil, args)   => q"${body}.apply(..$args)"
-        case (targs, args) => q"${body}.apply[..$targs](..$args)"
+        case (targs, Nil)  => q"$body.apply[..$targs]"
+        case (Nil, args)   => q"$body.apply(..$args)"
+        case (targs, args) => q"$body.apply[..$targs](..$args)"
       }
     }
 
-    def getInvokedSymbol(field: Select): Symbol = {
+    private def getInvokedSymbol(field: Select): Symbol = {
       field.symbol.annotations.find(_.tree.tpe <:< c.typeOf[reifyAs]).map { _ =>
         field.symbol
       }.getOrElse {
@@ -46,13 +48,16 @@ trait ReifyAsEmbedding extends DirectEmbeddingModule with DirectEmbeddingUtils {
       }
     }
 
+    private def isNotModule(tree: Tree): Boolean =
+      tree.symbol != null && !tree.symbol.isModule
+
     /**
      * Returns transformed tree if tree is a class instance, None otherwise
      */
-    def getSelf(x: Tree): Option[Tree] = {
-      Option(x).withFilter { t =>
-        t.symbol != null && !t.symbol.isModule
-      }.map(transform)
+    private def getSelf(lhs: Tree): Option[Tree] = lhs match {
+      case Select(x, _) if isNotModule(x) => Some(x)
+      case TypeApply(Select(x, _), _) if isNotModule(x) => Some(x)
+      case _ => None
     }
 
     /**
@@ -64,14 +69,30 @@ trait ReifyAsEmbedding extends DirectEmbeddingModule with DirectEmbeddingUtils {
      * @param args List[Tree] arguments to prepend to uncurried argument list
      * @return Uncurried tree
      */
-    def uncurry(t: Tree, args: List[Tree]): Tree = t match {
+    private def uncurry(t: Tree, args: List[Tree]): Tree = t match {
       case field @ Apply(x, y) =>
         uncurry(x, y ::: args)
       case _ =>
         Apply(t, args)
     }
 
-    var indent: Int = 0
+    private var indent: Int = 0
+
+    private def typeArgs(lhs: Tree): List[Tree] = lhs match {
+      case Select(x, _)        => x.tpe.typeArgs.map(TypeTree(_))
+      case TypeApply(_, targs) => targs
+      case _                   => Nil
+    }
+
+    private def args(lhs: Tree, rhs: List[Tree]): List[Tree] =
+      (getSelf(lhs).toList ::: rhs).map(transform)
+
+    private def symbol(lhs: Tree): Symbol = lhs match {
+      case Select(New(newBody), _)            => newBody.symbol
+      case field @ Select(_, _)               => getInvokedSymbol(field)
+      case TypeApply(field @ Select(_, _), _) => getInvokedSymbol(field)
+      case _                                  => lhs.symbol
+    }
 
     override def transform(tree: Tree): Tree = {
       logIndented(s"transform(): $tree", indent, logLevel)
@@ -80,52 +101,22 @@ trait ReifyAsEmbedding extends DirectEmbeddingModule with DirectEmbeddingUtils {
       val result = tree match {
         case a @ Apply(Apply(_, _), _) =>
           logIndented(s"Apply(Apply)", indent, logLevel)
-          val t = uncurry(a, Nil)
-          transform(t)
+          transform(uncurry(a, Nil))
 
-        // f(args)
-        case Apply(Select(New(newBody), _), cargs) =>
-          logIndented(s"Apply(Select(New)):", indent, logLevel)
-          val listArgs = newBody.tpe.typeArgs
-          reify(newBody.symbol, listArgs.map(TypeTree(_)), cargs)
+        case Apply(lhs, rhs) =>
+          logIndented(s"Apply(lhs, rhs)", indent, logLevel)
+          reify(symbol(lhs), typeArgs(lhs), args(lhs, rhs))
 
-        // f(args)
-        case Apply(field @ Select(x, _), args) =>
-          logIndented(s"Apply(Select):", indent, logLevel)
-          val invokedSymbol = getInvokedSymbol(field)
-          val self = getSelf(x).toList
-          reify(invokedSymbol, x.tpe.typeArgs.map(TypeTree(_)), self ::: args.map(transform(_)))
-
-        // f[T](args)
-        case Apply(TypeApply(field @ Select(x, _), targs), args) =>
-          logIndented(s"Apply(TypeApply):", indent, logLevel)
-          val invokedSymbol = getInvokedSymbol(field)
-          val self = getSelf(x).toList
-          reify(invokedSymbol, targs.map(transform(_)), self ::: args.map(transform(_)))
-
-        case Apply(lhs, args) =>
-          logIndented(s"Apply() fallback:", indent, logLevel)
-          reify(lhs.symbol, Nil, args)
-
-        // f[T]
-        case TypeApply(field @ Select(x, _), targs) =>
+        case TypeApply(lhs, targs) =>
           logIndented(s"TypeApply", indent, logLevel)
-          val invokedSymbol = getInvokedSymbol(field)
-          val self = getSelf(x).toList
-          reify(invokedSymbol, x.tpe.typeArgs.map(TypeTree(_)) ::: targs.map(transform(_)), self)
+          reify(symbol(lhs), typeArgs(lhs) ::: targs, args(lhs, Nil))
 
-        // obj.field
-        case field @ Select(x, _) =>
+        case lhs @ Select(x, _) =>
           logIndented(s"Select()", indent, logLevel)
-          val invokedSymbol = getInvokedSymbol(field)
-          val self = getSelf(x).toList
-          reify(invokedSymbol, x.tpe.typeArgs.map(TypeTree(_)), self)
+          reify(symbol(lhs), typeArgs(lhs), args(lhs, Nil))
 
-        case _: Import => {
-          logIndented(s"Import", indent, logLevel)
-          logTree(tree, logLevel + 1)
+        case _: Import =>
           tree
-        }
 
         case _ =>
           logIndented(s"other branch:", indent, logLevel)

--- a/tests/src/test/scala/ch/epfl/directembedding/test/BasicSpec.scala
+++ b/tests/src/test/scala/ch/epfl/directembedding/test/BasicSpec.scala
@@ -5,16 +5,6 @@ import org.scalatest.{ FlatSpec, ShouldMatchers }
 import Typecheck._
 import ch.epfl.directembedding.test.example._
 
-trait ExampleTester extends FlatSpec {
-  def runTest[T](body: => T): Exp[T] = {
-    intercept[scala.NotImplementedError] {
-      body
-    }
-    Q.poll().asInstanceOf[Exp[T]]
-  }
-
-}
-
 class BasicSpec extends FlatSpec with ShouldMatchers with ExampleTester {
 
   "dsl" should "work object fields" in {

--- a/tests/src/test/scala/ch/epfl/directembedding/test/ExampleTester.scala
+++ b/tests/src/test/scala/ch/epfl/directembedding/test/ExampleTester.scala
@@ -1,0 +1,14 @@
+package ch.epfl.directembedding.test
+
+import org.scalatest.{ FlatSpec, ShouldMatchers }
+import ch.epfl.directembedding.test.example._
+
+trait ExampleTester extends FlatSpec {
+  def runTest[T](body: => T): Exp[T] = {
+    intercept[scala.NotImplementedError] {
+      body
+    }
+    Q.poll().asInstanceOf[Exp[T]]
+  }
+
+}


### PR DESCRIPTION
First fix for #14. This refactoring will make it easier to add type-transformation/overriding in ReifyAsEmbedding.