### PR TITLE
Allow reification of third-party libraries, closes #14

### DIFF
--- a/directembedding/src/main/scala/ch/epfl/directembedding/DETransformer.scala
+++ b/directembedding/src/main/scala/ch/epfl/directembedding/DETransformer.scala
@@ -11,6 +11,7 @@ object DETransformer {
 
   def apply[C <: blackbox.Context, T, D <: DslConfig](c: C)(
     _dslName: String,
+    _typeMap: Map[c.universe.Type, c.universe.Type],
     postProcessing: Option[PostProcessing[c.type]],
     preProcessing: Option[PreProcessing[c.type]],
     debug: Boolean = false)(implicit tag: WeakTypeTag[D]): DETransformer[c.type, T] = {
@@ -24,6 +25,10 @@ object DETransformer {
       val preProcessor = preProcessing.getOrElse(new NullPreProcessing[c.type](c))
       val dslName: String = _dslName
       val configPath: Tree = dslConfig
+      override val typeMap: Map[String, Type] = _typeMap.map {
+        case (k, v) =>
+          (k.typeSymbol.fullName, v)
+      }
       override val debugLevel = if (debug) 2 else 0
       val logLevel: Int = 0
     }

--- a/directembedding/src/main/scala/ch/epfl/directembedding/transformers/ReifyAsEmbedding.scala
+++ b/directembedding/src/main/scala/ch/epfl/directembedding/transformers/ReifyAsEmbedding.scala
@@ -1,31 +1,30 @@
 package ch.epfl.directembedding.transformers
 
-import ch.epfl.directembedding.{ DirectEmbeddingModule, DirectEmbeddingUtils, MacroModule }
+import ch.epfl.directembedding.{ TypeHelper, DirectEmbeddingModule, DirectEmbeddingUtils, MacroModule }
 
 class reifyAs(to: Any) extends scala.annotation.StaticAnnotation
 class ignore extends scala.annotation.StaticAnnotation
 
-trait ReifyAsEmbedding extends DirectEmbeddingModule with DirectEmbeddingUtils {
+trait ReifyAsEmbedding extends DirectEmbeddingModule
+  with DirectEmbeddingUtils
+  with TypeHelper {
   import c.universe._
 
   object ReifyAsTransformer extends (Tree => Tree) {
     def apply(tree: Tree) = {
-      logStarred("Before ReifyAsEmbedding", logLevel)
-      new ReifyAsTransformer(tree.pos).apply(tree)
+      logStarred("Before ReifyAsEmbedding")
+      new ReifyAsTransformer().apply(tree)
     }
   }
 
-  final class ReifyAsTransformer(pos: Position) extends Transformer {
+  final class ReifyAsTransformer extends Transformer {
     def apply(tree: Tree): Tree = transform(tree)
 
-    private def getReifyAnnotation(methodSym: Symbol): Option[Annotation] =
+    private def reifyAnnotation(methodSym: Symbol): Option[Annotation] =
       methodSym.annotations.find(_.tree.tpe <:< c.typeOf[reifyAs])
 
-    private def reify(methodSym: Symbol, targs: List[Tree], args: List[Tree]): Tree = {
-      val annotation = getReifyAnnotation(methodSym).getOrElse {
-        c.abort(pos, s"$methodSym is not supported in $dslName")
-      }
-      reify(annotation.tree.children.tail.head, targs, args)
+    private def reify(lhs: Tree, tree: Tree, extraTargs: List[Tree], extraArgs: List[Tree]): Tree = {
+      reify(body(lhs, tree), typeArgs(lhs) ::: extraTargs, args(lhs, extraArgs))
     }
 
     private def reify(body: Tree, targs: List[Tree], args: List[Tree]): Tree = {
@@ -37,27 +36,13 @@ trait ReifyAsEmbedding extends DirectEmbeddingModule with DirectEmbeddingUtils {
       }
     }
 
-    private def getInvokedSymbol(field: Select): Symbol = {
-      field.symbol.annotations.find(_.tree.tpe <:< c.typeOf[reifyAs]).map { _ =>
-        field.symbol
-      }.getOrElse {
-        // Value member compiled to private variable
-        field.symbol.owner.info.members.find(x => x.name.toString.trim == field.symbol.name.toString.trim).getOrElse {
-          throw new RuntimeException(s"Unable to get value member $field. ${showRaw(field)}")
-        }
+    private def isNotModule(tree: Tree): Boolean = {
+      val expr = tree match {
+        // Typed blocks have no symbol
+        case Typed(lhs, typ) => lhs
+        case _               => tree
       }
-    }
-
-    private def isNotModule(tree: Tree): Boolean =
-      tree.symbol != null && !tree.symbol.isModule
-
-    /**
-     * Returns transformed tree if tree is a class instance, None otherwise
-     */
-    private def getSelf(lhs: Tree): Option[Tree] = lhs match {
-      case Select(x, _) if isNotModule(x) => Some(x)
-      case TypeApply(Select(x, _), _) if isNotModule(x) => Some(x)
-      case _ => None
+      expr.symbol != null && !expr.symbol.isModule
     }
 
     /**
@@ -76,7 +61,22 @@ trait ReifyAsEmbedding extends DirectEmbeddingModule with DirectEmbeddingUtils {
         Apply(t, args)
     }
 
-    private var indent: Int = 0
+    private def invokedSymbol(field: Select): Symbol = {
+      field.symbol.annotations.find(_.tree.tpe <:< c.typeOf[reifyAs]).map { _ =>
+        field.symbol
+      }.getOrElse {
+        // Value member compiled to private variable
+        field.symbol.owner.info.members.find(equalSymbols(field.symbol)).getOrElse {
+          throw new RuntimeException(s"Unable to get value member $field. ${showRaw(field)}")
+        }
+      }
+    }
+
+    private def self(lhs: Tree): Option[Tree] = lhs match {
+      case Select(x, _) if isNotModule(x) => Some(x)
+      case TypeApply(Select(x, _), _) if isNotModule(x) => Some(x)
+      case _ => None
+    }
 
     private def typeArgs(lhs: Tree): List[Tree] = lhs match {
       case Select(x, _)        => x.tpe.typeArgs.map(TypeTree(_))
@@ -84,42 +84,90 @@ trait ReifyAsEmbedding extends DirectEmbeddingModule with DirectEmbeddingUtils {
       case _                   => Nil
     }
 
-    private def args(lhs: Tree, rhs: List[Tree]): List[Tree] =
-      (getSelf(lhs).toList ::: rhs).map(transform)
-
-    private def symbol(lhs: Tree): Symbol = lhs match {
-      case Select(New(newBody), _)            => newBody.symbol
-      case field @ Select(_, _)               => getInvokedSymbol(field)
-      case TypeApply(field @ Select(_, _), _) => getInvokedSymbol(field)
-      case _                                  => lhs.symbol
+    private def args(lhs: Tree, rhs: List[Tree]): List[Tree] = {
+      (self(lhs).toList ::: rhs).map(transform)
     }
 
+    private def symbol(lhs: Tree): Symbol = lhs match {
+      case Select(New(newBody), _)     => newBody.symbol
+      case field: Select               => invokedSymbol(field)
+      case TypeApply(field: Select, _) => invokedSymbol(field)
+      case _                           => lhs.symbol
+    }
+
+    private def selfType(tree: Tree): Type = {
+      val owner = tree.symbol.owner
+      if (owner.isType) owner.asType.toType
+      else throw new RuntimeException(s"Unable to find type of $tree")
+    }
+
+    private def fallbackAnnotation(treeSymbol: Symbol, tree: Tree): Option[Annotation] =
+      for {
+        fallbackType <- typeMap.get(selfType(tree).typeSymbol.fullName)
+        fallbackSymbol <- {
+          log(s"Falling back to $fallbackType")
+          findMatchingSymbol(treeSymbol, fallbackType)
+        }
+        fallbackAnnotation <- {
+          log(s"Found matching symbol in overridden type: $fallbackSymbol")
+          reifyAnnotation(fallbackSymbol)
+        }
+      } yield fallbackAnnotation
+
+    /**
+     * Get body of class to be reified through [[reifyAs]] annotation.
+     *
+     * First, performs lookup for the [[reifyAs]] annotation in the invoked
+     * symbol and falls back to a lookup in [[typeMap]] for the type of
+     * parameter `tree` if no annotation exists.
+     *
+     * @param lhs Tree that was invoked
+     * @param tree Tree to be reified through annotation
+     * @return Reified tree if annotation exists, fails compilation otherwise
+     */
+    private def body(lhs: Tree, tree: Tree): Tree = {
+      val treeSymbol = symbol(lhs)
+      reifyAnnotation(treeSymbol).orElse {
+        log(s"Missing reifyAs annotation for $treeSymbol")
+        fallbackAnnotation(treeSymbol, tree)
+      }.map {
+        _.tree.children.tail.headOption.getOrElse {
+          throw new IllegalArgumentException("Missing argument for reifyAs annotation")
+        }
+      }.getOrElse {
+        c.abort(tree.pos, s"$treeSymbol on ${selfType(tree).typeSymbol} is not supported in $dslName")
+      }
+    }
+
+    private var indent: Int = 0
+
     override def transform(tree: Tree): Tree = {
-      logIndented(s"transform(): $tree", indent, logLevel)
+      logIndented(s"transform(): $tree", indent)
       logTree(tree, logLevel + 1)
       indent += 2
       val result = tree match {
+        // f(a)(b) => f(a, b)
         case a @ Apply(Apply(_, _), _) =>
-          logIndented(s"Apply(Apply)", indent, logLevel)
+          logIndented(s"Apply(Apply)", indent)
           transform(uncurry(a, Nil))
 
         case Apply(lhs, rhs) =>
-          logIndented(s"Apply(lhs, rhs)", indent, logLevel)
-          reify(symbol(lhs), typeArgs(lhs), args(lhs, rhs))
+          logIndented(s"Apply(lhs, rhs)", indent)
+          reify(lhs, tree, Nil, rhs)
 
         case TypeApply(lhs, targs) =>
-          logIndented(s"TypeApply", indent, logLevel)
-          reify(symbol(lhs), typeArgs(lhs) ::: targs, args(lhs, Nil))
+          logIndented(s"TypeApply", indent)
+          reify(lhs, tree, targs, Nil)
 
         case lhs @ Select(x, _) =>
-          logIndented(s"Select()", indent, logLevel)
-          reify(symbol(lhs), typeArgs(lhs), args(lhs, Nil))
+          logIndented(s"Select()", indent)
+          reify(lhs, tree, Nil, Nil)
 
         case _: Import =>
           tree
 
         case _ =>
-          logIndented(s"other branch:", indent, logLevel)
+          logIndented(s"other branch:", indent)
           super.transform(tree)
       }
       indent -= 2

--- a/dsls/src/main/scala/ch/epfl/directembedding/test/TestBase.scala
+++ b/dsls/src/main/scala/ch/epfl/directembedding/test/TestBase.scala
@@ -52,6 +52,12 @@ case class Infix_ValDef[T](t: Exp[T]) extends Exp[T]
 case object ClassCons extends Exp[ClassExample]
 case class TArgClassExampleCase[T]() extends Exp[T]
 
+case class IntPlus[T](self: Exp[T], that: Exp[Int]) extends Exp[Int]
+case class StringLength[T](self: Exp[T]) extends Exp[Int]
+case class StringConcat[T](self: Exp[T], that: Exp[String]) extends Exp[String]
+case class MyTArgs[T](self: Exp[_]) extends Exp[T]
+case class MyTArgsObject[T]() extends Exp[T]
+
 // Example Object with all corner cases.
 object ObjectExample {
   @reifyAs(ValDef)
@@ -119,4 +125,46 @@ class TArgClassExample[T] {
 @reifyAs(ClassCons)
 class ClassExample {
   val dummyVal: Int = 1
+}
+
+// **********************************
+// Standard and third-party libraries
+// **********************************
+class MyInt {
+  @reifyAs(IntPlus)
+  def +(x: Int): Int = ???
+}
+
+class MyString {
+  @reifyAs(StringLength)
+  def length(): Int = ???
+
+  @reifyAs(StringConcat)
+  def concat(that: String): String = ???
+}
+
+trait ThirdPartyObject
+
+object ThirdPartyObject extends ThirdPartyObject {
+  def targs[T]: T = ???
+}
+
+case class ThirdPartyClass() {
+  def targs[T]: T = ???
+}
+
+trait MyThirdPartyObject {
+  @reifyAs(MyTArgsObject)
+  def targs[T]: T = ???
+}
+
+class MyThirdPartyLibrary() {
+  // Note the explicit parenthesis, the body is reified
+  // exactly as it appears in the annotation
+  @reifyAs(ThirdPartyClass())
+  def apply(): MyThirdPartyLibrary = ???
+
+  @reifyAs(MyTArgs)
+  def targs[T]: T = ???
+
 }

--- a/dsls/src/main/scala/ch/epfl/directembedding/test/example/package.scala
+++ b/dsls/src/main/scala/ch/epfl/directembedding/test/example/package.scala
@@ -127,6 +127,11 @@ package object example {
       val config = "ch.epfl.directembedding.test.example"
       DETransformer[c.type, T, ExampleConfig](c)(
         "example.dsl",
+        Map(
+          c.typeTag[Int].tpe -> c.typeTag[MyInt].tpe,
+          c.typeTag[String].tpe -> c.typeTag[MyString].tpe,
+          c.typeTag[ThirdPartyClass].tpe -> c.typeTag[MyThirdPartyLibrary].tpe,
+          c.typeTag[ThirdPartyObject].tpe -> c.typeTag[MyThirdPartyObject].tpe),
         None,
         // Note the explicit `apply`, this is necessary.
         None,

--- a/tests/src/test/scala/ch/epfl/directembedding/test/BasicSpec.scala
+++ b/tests/src/test/scala/ch/epfl/directembedding/test/BasicSpec.scala
@@ -8,7 +8,7 @@ import ch.epfl.directembedding.test.example._
 class BasicSpec extends FlatSpec with ShouldMatchers with ExampleTester {
 
   "dsl" should "work object fields" in {
-    runTest[Int](
+    runTest(
       dsl {
         ObjectExample.valDef
       }) should be(ValDef)

--- a/tests/src/test/scala/ch/epfl/directembedding/test/ErrorsSpec.scala
+++ b/tests/src/test/scala/ch/epfl/directembedding/test/ErrorsSpec.scala
@@ -9,11 +9,20 @@ class ErrorsSpec extends FlatSpec with ShouldMatchers with ExampleTester {
   "dsl" should "give a useful error when a reifyAs annotation is missing" in {
     typedWithMsg(
       """
-        runTest(
-          dsl {
-            ObjectExample.missingAnnotation
-        }) should be(???)
-      """, "method missingAnnotation is not supported in example.dsl")
+        dsl {
+          ObjectExample.missingAnnotation
+        }
+      """, "method missingAnnotation on object ObjectExample is not supported in example.dsl")
+  }
+
+  "dsl" should "give a useful error when a reifyAs annotation is missing in fallback type" in {
+    typedWithMsg(
+      """
+        dsl {
+          val s = "foobar"
+          s.charAt(1)
+        }
+      """, "method charAt on class String is not supported in example.dsl")
   }
 
 }

--- a/tests/src/test/scala/ch/epfl/directembedding/test/TypeOverridingSpec.scala
+++ b/tests/src/test/scala/ch/epfl/directembedding/test/TypeOverridingSpec.scala
@@ -1,0 +1,56 @@
+package ch.epfl.directembedding.test
+
+import ch.epfl.directembedding.test.example._
+import org.scalatest.{ FlatSpec, ShouldMatchers }
+
+class TypeOverridingSpec extends FlatSpec with ShouldMatchers with ExampleTester {
+
+  "dsl" should "allow custom overriding of Int.+" in {
+    runTest(
+      dsl {
+        val i = 2
+        i + 1
+      }) should be(IntPlus(Infix_ValDef(2), 1))
+  }
+
+  // This case is different from IntPlus because the
+  // type of `s` is String and the result is of type Int
+  "dsl" should "allow custom overriding of String.length" in {
+    runTest(
+      dsl {
+        val s = "foobar"
+        s.length
+      }) should be(StringLength(Infix_ValDef("foobar")))
+  }
+
+  "dsl" should "allow custom overriding of String.concat" in {
+    runTest(
+      dsl {
+        val s = "foobar"
+        s.concat("kaz")
+      }) should be(StringConcat(Infix_ValDef("foobar"), "kaz"))
+  }
+
+  "dsl" should "allow custom overriding of val.targs[T]" in {
+    val l = new ThirdPartyClass()
+    runTest(
+      dsl {
+        l.targs[Int]
+      }) should be(MyTArgs[Int](ThirdPartyClass()))
+  }
+
+  "dsl" should "allow custom overriding of ThirdPartyClass().targs[T]" in {
+    runTest(
+      dsl {
+        ThirdPartyClass().targs[Int]
+      }) should be(MyTArgs[Int](Const(ThirdPartyClass())))
+  }
+
+  "dsl" should "allow custom overriding of ThirdPartyObject().targs[T]" in {
+    runTest(
+      dsl {
+        ThirdPartyObject.targs[Int]
+      }) should be(MyTArgsObject[Int]())
+  }
+
+}


### PR DESCRIPTION
We configure the overriding with a `typeMap: Map[Type, Type]`.  We
perform the type overriding as an integral part of the ReifyAsEmbedding
phase, more precisely in the `body` method.

The benefit of this approach is that we don't have to type-rewrite any
nodes in the block. This means the reification of standard and
third-party types will only trigger if the DSL author provides an
implementation of the invoked method in the corresponding type in
`typeMap`. If no matching method (see bottom comment) with a `reifyAs`
annotation is found in the corresponding type the transformation falls
back to the general error message, i.e. 'method X is not supported in
DSL'.

The limitation of this approach is mainly that we cannot override a type
if the method already contains a `reifyAs` annotation. We accept this
limitation since (presumably) the standard and third-party libraries
won't have the annotations in the first place.

This commit does not provide a solution for method overloading.
